### PR TITLE
manifest version upgraded

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
-    "manifest_version": 2,
+    "manifest_version": 3,
     "name": "TradingView NoAds",
-    "version": "0.2",
+    "version": "0.3",
     "description": "Removes the annoying ads and the upgrade to pro message in TradingView",
-    "browser_action": {
+    "action": {
 	    "default_icon": {
         "128": "icon-128.png"
       }


### PR DESCRIPTION
Resolved Error : Manifest version 2 is deprecated, and support will be removed in 2023. 